### PR TITLE
Revert "Fix clippy: match expr looks like matches! macro"

### DIFF
--- a/src/strand.rs
+++ b/src/strand.rs
@@ -53,10 +53,11 @@ impl Strand {
 impl PartialEq for Strand {
     /// Returns true if both are `Forward` or both are `Reverse`, otherwise returns false.
     fn eq(&self, other: &Strand) -> bool {
-        matches!(
-            (self, other),
-            (&Strand::Forward, &Strand::Forward) | (&Strand::Reverse, &Strand::Reverse)
-        )
+        match (self, other) {
+            (&Strand::Forward, &Strand::Forward) => true,
+            (&Strand::Reverse, &Strand::Reverse) => true,
+            _ => false,
+        }
     }
 }
 
@@ -73,12 +74,12 @@ impl Neg for Strand {
 
 impl Same for Strand {
     fn same(&self, s1: &Self) -> bool {
-        matches!(
-            (*self, *s1),
-            (Strand::Forward, Strand::Forward)
-                | (Strand::Reverse, Strand::Reverse)
-                | (Strand::Unknown, Strand::Unknown)
-        )
+        match (*self, *s1) {
+            (Strand::Forward, Strand::Forward) => true,
+            (Strand::Reverse, Strand::Reverse) => true,
+            (Strand::Unknown, Strand::Unknown) => true,
+            _ => false,
+        }
     }
 }
 

--- a/src/strand.rs
+++ b/src/strand.rs
@@ -50,6 +50,7 @@ impl Strand {
     }
 }
 
+#[allow(clippy::match_like_matches_macro)]
 impl PartialEq for Strand {
     /// Returns true if both are `Forward` or both are `Reverse`, otherwise returns false.
     fn eq(&self, other: &Strand) -> bool {
@@ -72,6 +73,7 @@ impl Neg for Strand {
     }
 }
 
+#[allow(clippy::match_like_matches_macro)]
 impl Same for Strand {
     fn same(&self, s1: &Self) -> bool {
         match (*self, *s1) {


### PR DESCRIPTION
This reverts commit 91fc873bc2a6213a49daec7819c23a5f97f6d740, which was a part of #16. 

It turns out that the `matches!` macro that `clippy` suggested was only [stabilized in 1.42](https://doc.rust-lang.org/std/macro.matches.html) ([2020-03-12](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1420-2020-03-12)). It is probably safer to revert in order to avoid breaking older code, which happened here: https://github.com/rust-bio/rust-bio/issues/410