### PR TITLE
fix: Fix `'\'` being rendered as ’' on docs.rs

### DIFF
--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -157,7 +157,7 @@ impl Alignment {
     /// sequence x, second line is for the alignment operation and the
     /// the third line is for the sequence y. A '-' in the sequence
     /// indicates a blank (insertion/deletion). The operations follow
-    /// the following convention: '|' for a match, '\\' for a mismatch,
+    /// the following convention: '|' for a match, '\\' (a single backslash) for a mismatch,
     /// '+' for an insertion, 'x' for a deletion and ' ' for clipping
     ///
     /// # Example

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -157,7 +157,7 @@ impl Alignment {
     /// sequence x, second line is for the alignment operation and the
     /// the third line is for the sequence y. A '-' in the sequence
     /// indicates a blank (insertion/deletion). The operations follow
-    /// the following convention: '|' for a match, '\' for a mismatch,
+    /// the following convention: '|' for a match, '\\' for a mismatch,
     /// '+' for an insertion, 'x' for a deletion and ' ' for clipping
     ///
     /// # Example


### PR DESCRIPTION
Before, this would [render](https://docs.rs/bio-types/0.12.0/bio_types/alignment/struct.Alignment.html#method.pretty) as two quotes since the `\` escapes the closing quote. Escaping the backslach itself should fix this.

Could also add `(a single backslash)` to clarify it for those reading the source instead of the online docs.

