### PR TITLE
build: Update Strum to Latest Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,12 +55,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "indexmap"
@@ -157,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ad150e9d51e33e8142984f577662c1324d49f3be45ed37bac8645fdcbe0fe5"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -198,12 +195,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ regex = "1.0"
 lazy_static = "1.1"
 derive-new = "0.5"
 petgraph = { version = ">=0.5,<0.7", optional = true }
-strum_macros = "0.24"
+strum_macros = ">=0.20, <0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ regex = "1.0"
 lazy_static = "1.1"
 derive-new = "0.5"
 petgraph = { version = ">=0.5,<0.7", optional = true }
-strum_macros = ">=0.20, <0.24"
+strum_macros = "0.24"

--- a/src/annot/contig.rs
+++ b/src/annot/contig.rs
@@ -468,6 +468,17 @@ mod tests {
     }
 
     #[test]
+    fn test_display_fmt() {
+        let tma19 = Contig::new(
+            "chrXI".to_owned(),
+            334412,
+            334916 - 334412,
+            ReqStrand::Reverse,
+        );
+        assert_eq!(format!("{}", tma19), "chrXI:334412-334916(-)");
+    }
+
+    #[test]
     fn intersection() {
         test_contig_ixn(
             "chrX:461829-462426(+)",


### PR DESCRIPTION
Currently is < 0.24, but figure we'll need to cross that bridge eventually.