### PR TITLE
feat: strand: Use +/- rather than (+)/(-) for str

### DIFF
--- a/src/annot/contig.rs
+++ b/src/annot/contig.rs
@@ -287,17 +287,21 @@ impl<R, S> Loc for Contig<R, S> {
 impl<R, S> Display for Contig<R, S>
 where
     R: Display,
-    S: Display,
+    S: Display + Clone + Into<Strand>,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "{}:{}-{}{}",
+            "{}:{}-{}",
             self.refid,
             self.start,
-            self.start + self.length as isize,
-            self.strand
-        )
+            self.start + self.length as isize
+        )?;
+        let strand: Strand = self.strand.clone().into();
+        if !strand.is_unknown() {
+            write!(f, "({})", strand)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/annot/pos.rs
+++ b/src/annot/pos.rs
@@ -227,10 +227,15 @@ where
 impl<R, S> Display for Pos<R, S>
 where
     R: Display,
-    S: Display,
+    S: Display + Clone + Into<Strand>,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}:{}{}", self.refid, self.pos, self.strand)
+        let strand: Strand = self.strand.clone().into();
+        if strand.is_unknown() {
+            write!(f, "{}:{}", self.refid, self.pos)
+        } else {
+            write!(f, "{}:{}({})", self.refid, self.pos, strand)
+        }
     }
 }
 

--- a/src/annot/spliced.rs
+++ b/src/annot/spliced.rs
@@ -545,7 +545,7 @@ impl<R, S> Loc for Spliced<R, S> {
 impl<R, S> Display for Spliced<R, S>
 where
     R: Display,
-    S: Display,
+    S: Display + Clone + Into<Strand>,
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}:", self.refid)?;
@@ -562,7 +562,11 @@ where
             )?;
             sep = true;
         }
-        write!(f, "{}", self.strand)
+        let strand: Strand = self.strand.clone().into();
+        if !strand.is_unknown() {
+            write!(f, "({})", self.strand)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/strand.rs
+++ b/src/strand.rs
@@ -91,10 +91,7 @@ impl Same for Strand {
 
 impl Display for Strand {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match *self {
-            Strand::Unknown => Ok(()),
-            _ => write!(f, "({})", self.strand_symbol()),
-        }
+        f.write_str(self.strand_symbol())
     }
 }
 
@@ -102,9 +99,9 @@ impl FromStr for Strand {
     type Err = StrandError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "" => Ok(Strand::Unknown),
-            "(+)" => Ok(Strand::Forward),
-            "(-)" => Ok(Strand::Reverse),
+            "+" | "(+)" => Ok(Strand::Forward),
+            "-" | "(-)" => Ok(Strand::Reverse),
+            "." | "" => Ok(Strand::Unknown),
             _ => Err(StrandError::ParseError),
         }
     }
@@ -200,10 +197,7 @@ impl Same for ReqStrand {
 
 impl Display for ReqStrand {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            ReqStrand::Forward => write!(f, "(+)"),
-            ReqStrand::Reverse => write!(f, "(-)"),
-        }
+        f.write_str(self.strand_symbol())
     }
 }
 
@@ -211,8 +205,8 @@ impl FromStr for ReqStrand {
     type Err = StrandError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "(+)" => Ok(ReqStrand::Forward),
-            "(-)" => Ok(ReqStrand::Reverse),
+            "+" | "(+)" => Ok(ReqStrand::Forward),
+            "-" | "(-)" => Ok(ReqStrand::Reverse),
             _ => Err(StrandError::ParseError),
         }
     }


### PR DESCRIPTION
Change the string representation of Strand to `"+"`, `"-"`, `"."`.
The current string representation is `"(+)"`, `"(-)"`, and `""`.

See https://github.com/rust-bio/rust-bio-types/pull/8#issuecomment-539450970

>> Why was `(+)`, `(-)` and empty string chosen as the Display representation for Forward, Reverse, and Unknown? `+`, `-`, and `.` would be more natural and useful to me.

> Mhm, this somehow slipped my attention before. I think changing it to +-. would be fine, and indeed more intuitive. Please just change it. Then, there is no need for the strand_symbol method, right?

I'm not a hundred percent convinced this PR should be merged, because it could be a breaking change, and required changes to `fmt` of `Pos`, `Spliced, and `Contig` to maintain their previous string representation, but looking at `strand` alone, it seems like a desirable change to me.

Rather than requiring that the `Strand`-like type parameter of `Pos`, `Spliced`, and `Contig` implement `Into<Strand>`, we could instead add a `Strand`-like trait.