### PR TITLE
fix: make dependabot commit message follow conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      # Prefix all commit messages with "deps: ", which should be
+      # accepted as a conventional commit and trigger release-please
+      prefix: "deps"


### PR DESCRIPTION
for conventional commits, see: 
https://www.conventionalcommits.org/en/v1.0.0/

for a good cheat sheet, see:
https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index