### PR TITLE
chore: relax version reqs on thiserror and derive-new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ phylogeny = ["petgraph"]
 [dependencies]
 serde = { version = "^1", optional = true, features=["derive"] }
 clap = { version = ">=3.2.0", optional = true, features = ["derive"] }
-thiserror = "1"
+thiserror = ">=1, <3"
 regex = "1.10"
 lazy_static = "1.5"
-derive-new = "0.6"
+derive-new = ">=0.6, <0.8"
 petgraph = { version = ">=0.5, <0.7", optional = true }
 strum_macros = ">=0.20, <0.27"


### PR DESCRIPTION
- strict version requirements there cause issues when updating downstream with other libraries (like [rust-htslib](https://github.com/rust-bio/rust-htslib))